### PR TITLE
feat: Added APIs for adding removing namespace maintainers

### DIFF
--- a/flask/namespaces.py
+++ b/flask/namespaces.py
@@ -42,9 +42,13 @@ def delete_namespace(namespace_name):
 
 @app.route("/namespace/<namespace>", methods=["GET"])
 def namespace_packages(namespace):
-    namespace_packages = db.namespaces.find_one({"namespace": namespace})
+    namespace_document = db.namespaces.find_one({"namespace": namespace})
+
+    if not namespace_document:
+        return jsonify({"code": 404, "message": "Namespace not found"}), 404
+
     packages = []
-    for i in namespace_packages["packages"]:
+    for i in namespace_document["packages"]:
         package = db.packages.find(
             {"_id": i},
             {
@@ -66,7 +70,7 @@ def namespace_packages(namespace):
             {
                 "status": 200,
                 "packages": packages,
-                "createdAt": namespace_packages["createdAt"],
+                "createdAt": namespace_document["createdAt"],
             }
         ),
         200,

--- a/flask/user.py
+++ b/flask/user.py
@@ -324,8 +324,6 @@ def add_maintainers_to_namespace(username):
     uuid = request.form.get("uuid")
     username_to_be_added = request.form.get("username")
     namespace = request.form.get("namespace")
-    if not uuid:
-        return jsonify({"message": "Unauthorized", "code": 401}), 401
     
     # Validating the data coming with request.
     if not uuid:

--- a/flask/user.py
+++ b/flask/user.py
@@ -300,8 +300,8 @@ def remove_maintainers_from_package(username):
         return jsonify({"message": "Package not found", "code": 404}), 404
 
     # Check if the current user has authority to remove maintainers.
-    if not checkIsNamespaceAdmin(user_id=user["_id"], namespace=package_namespace) and not checkIsMaintainer(user_id=user["_id"], package=curr_package):
-        return jsonify({"message": "Unauthorized", "code": 401}), 401
+    if not checkIsNamespaceAdmin(user_id=user["_id"], namespace=package_namespace):
+        return jsonify({"message": "User is not authorized to remove maintainers", "code": 401}), 401
     
     # Get the user to be removed using the username received in the request body.
     user_to_be_removed = db.users.find_one({"username": username_to_be_removed})

--- a/flask/user.py
+++ b/flask/user.py
@@ -278,13 +278,6 @@ def remove_maintainers_from_package(username):
     if not user or user["username"] != username:
         return jsonify({"message": "Unauthorized", "code": 401}), 401
     
-    # Get the user from the database using uuid.
-    user = db.users.find_one({"uuid": uuid})
-
-    # Check if current user is authorized to access this API.
-    if not user or user["username"] != username:
-        return jsonify({"message": "Unauthorized", "code": 401}), 401
-    
     # Get the namespace from the database.
     package_namespace = db.namespaces.find_one({"namespace": namespace})
 
@@ -353,9 +346,6 @@ def add_maintainers_to_namespace(username):
 
     # Get the namespace from the database.
     namespace_doc = db.namespaces.find_one({"namespace": namespace})
-
-    print(namespace_doc["maintainers"])
-    print(namespace_doc["admins"])
 
     # Check if namespace does not exists.
     if not namespace_doc:


### PR DESCRIPTION
- [x] Don't allow package maintainers to remove other maintainers. Only namespace admins should be able to do that.
- [x] Added API to add namespace maintainers.
- [x] Added API to remove namespace maintainers.
- [x] Remove duplicate conditions from the remove package maintainers API 